### PR TITLE
Fall back to Coverage when SimpleCov was defined but not started

### DIFF
--- a/lib/single_cov.rb
+++ b/lib/single_cov.rb
@@ -94,11 +94,15 @@ module SingleCov
 
     # do not ask for coverage when SimpleCov already does or it conflicts
     def coverage_results
-      if defined?(SimpleCov)
+      if defined?(SimpleCov) && has_result?
         SimpleCov.instance_variable_get(:@result).original_result
       else
         Coverage.result
       end
+    end
+
+    def has_result?
+      !SimpleCov.instance_variable_get(:@result).nil?
     end
 
     # start recording before classes are loaded or nothing can be recorded

--- a/specs/single_cov_spec.rb
+++ b/specs/single_cov_spec.rb
@@ -33,7 +33,7 @@ describe SingleCov do
       end
     end
 
-    describe "when coverage has incresed" do
+    describe "when coverage has increased" do
       around { |t| change_file("test/a_test.rb", "SingleCov.covered!", "SingleCov.covered! uncovered: 1", &t) }
 
       # we might be running multiple files or have some special argument ... don't blow up
@@ -83,7 +83,7 @@ describe SingleCov do
       end
     end
 
-    it "does not complain when minitest was loaded befor setup" do
+    it "does not complain when minitest was loaded before setup" do
       change_file("test/a_test.rb", "require 'single_cov'", "require 'single_cov'\nmodule Minitest;end\n") do
         result = sh "ruby test/a_test.rb"
         assert_tests_finished_normally(result)
@@ -128,6 +128,18 @@ describe SingleCov do
           result = sh "ruby test/a_test.rb", fail: true
           assert_tests_finished_normally(result)
           expect(result).to include "4 / 5 LOC (80.0%) covered" # SimpleCov
+          expect(result).to include "(1 current vs 0 configured)" # SingleCov
+        end
+      end
+    end
+
+    describe "when SimpleCov was defined but did not start" do
+      around { |t| change_file("test/a_test.rb", default_setup, "#{default_setup}\nrequire 'simplecov'\n", &t) }
+
+      it "falls back to Coverage and complains" do
+        change_file 'lib/a.rb', "def a", "def b\n1\nend\ndef a" do
+          result = sh "ruby test/a_test.rb", fail: true
+          assert_tests_finished_normally(result)
           expect(result).to include "(1 current vs 0 configured)" # SingleCov
         end
       end


### PR DESCRIPTION
### Overview
Add test for `SimpleCov.instance_variable_get(:@result).nil?` in `coverage_results` since `SimpleCov` might be defined but not started.

I noticed this is the case when adding [Code Climate test reporter][1] to my own gem.

### Problem
When adding both `SingleCov` and `CodeClimate::TestReporter` to my `spec_helper` and running `rake spec` **locally**, I receive the following error:

```
gems/single_cov-0.2.2/lib/single_cov.rb:92:in `coverage_results': undefined method `original_result' for nil:NilClass (NoMethodError)
```

Here is my `spec_helper` header:

```ruby
require 'single_cov'
SingleCov.setup :rspec

require 'codeclimate-test-reporter'
CodeClimate::TestReporter.start
```

After digging a little, this is due to this check:

```ruby
if defined?(SimpleCov)
  SimpleCov.instance_variable_get(:@result).original_result
else
```

Indeed, `CodeClimate::TestReporter`, when running **locally**, [**doesn’t** start `SimpleCov`][2]. But it **does** require it nonetheless…

(I think the faulty class is their [`Formatter`][3])

### Proposed solution

Add an extra check for the value of `instance_variable_get(:@result)` and if `nil` fall back to `Coverage.result`.

[1]: https://github.com/codeclimate/ruby-test-reporter
[2]: https://github.com/codeclimate/ruby-test-reporter/blob/86d7a715f79814af0dbfd07d837614c0162bb41e/lib/code_climate/test_reporter.rb#L8
[3]: https://github.com/codeclimate/ruby-test-reporter/blob/86d7a715f79814af0dbfd07d837614c0162bb41e/lib/code_climate/test_reporter/formatter.rb#L7