### PR TITLE
also ignore option when used with equal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,3 @@ DEPENDENCIES
   rspec
   simplecov
   single_cov!
-
-BUNDLED WITH
-   1.12.5

--- a/lib/single_cov.rb
+++ b/lib/single_cov.rb
@@ -141,7 +141,7 @@ module SingleCov
     # do not record or verify when only running selected tests since it would be missing data
     def minitest_running_subset_of_tests?
       # via direct option (ruby test.rb -n /foo/)
-      (ARGV & ['-n', '--name', '-l', '--line']).any? ||
+      (ARGV.map { |a| a.split('=', 2).first } & ['-n', '--name', '-l', '--line']).any? ||
 
       # via testrbl or mtest or rails with direct line number (mtest test.rb:123)
       (ARGV.first =~ /:\d+\Z/) ||

--- a/specs/single_cov_spec.rb
+++ b/specs/single_cov_spec.rb
@@ -68,6 +68,12 @@ describe SingleCov do
         expect(result).to_not include "uncovered"
       end
 
+      it "does not complain when only running selected tests via = option" do
+        result = sh "ruby test/a_test.rb -n=/a/"
+        assert_tests_finished_normally(result)
+        expect(result).to_not include "uncovered"
+      end
+
       it "does not complain when only running selected tests via options and rails" do
         result = sh "bin/rails test test/a_test.rb -n '/foo/'"
         assert_tests_finished_normally(result)


### PR DESCRIPTION
Rubymine for example uses this to run tests:
/usr/bin/ruby -e $stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift) a_test.rb "--name=/test_\d+_does a/"

@bcolferzd