### PR TITLE
Adds check to ensure tests with 100% coverage maintain 100% coverage

### DIFF
--- a/lib/single_cov.rb
+++ b/lib/single_cov.rb
@@ -76,6 +76,26 @@ module SingleCov
       end
     end
 
+    def assert_full_coverage(tests: default_tests, currently_complete: [], currently_complete_file: "")
+      complete = tests.select { |file| File.read(file) =~ /SingleCov.covered!(\s*|\s*\#.*)$/ }
+      missing_complete = currently_complete - complete
+      newly_complete = complete - currently_complete
+      errors = []
+
+      unless missing_complete.empty?
+        errors << "The following file(s) were marked as 100% SingleCov test coverage (had no `coverage:` option) and are no longer. " +
+        "Please extend test coverage in these files to maintain 100% coverage. #{missing_complete}"
+      end
+
+      unless newly_complete.empty?
+        errors << "The following files are newly at 100% SingleCov test coverage. " +
+        "Please add the following to #{currently_complete_file} to ensure 100% coverage is maintained moving forward. " +
+        "#{newly_complete}"
+      end
+
+      raise errors.join("\n") unless errors.empty?
+    end
+
     def setup(framework, root: nil, branches: true, err: $stderr)
       @error_logger = err
 

--- a/lib/single_cov.rb
+++ b/lib/single_cov.rb
@@ -82,9 +82,9 @@ module SingleCov
       newly_complete = complete - currently_complete
       errors = []
 
-      unless missing_complete.empty?
-        errors << "The following file(s) were marked as 100% SingleCov test coverage (had no `coverage:` option) and are no longer. " +
-        "Please extend test coverage in these files to maintain 100% coverage. #{missing_complete}"
+      if missing_complete.any?
+        errors << "The following file(s) were previously marked as having 100% SingleCov test coverage (had no `coverage:` option) but are no longer marked as such.\n" +
+        "Please increase test coverage in these files to maintain 100% coverage and remove `coverage:` usage.\n#{missing_complete.join("\n")}"
       end
 
       unless newly_complete.empty?

--- a/lib/single_cov.rb
+++ b/lib/single_cov.rb
@@ -76,24 +76,24 @@ module SingleCov
       end
     end
 
-    def assert_full_coverage(tests: default_tests, currently_complete: [], currently_complete_file: "")
+    def assert_full_coverage(tests: default_tests, currently_complete: [], message: caller(0..1)[1])
       complete = tests.select { |file| File.read(file) =~ /SingleCov.covered!(\s*|\s*\#.*)$/ }
       missing_complete = currently_complete - complete
       newly_complete = complete - currently_complete
       errors = []
 
       if missing_complete.any?
-        errors << "The following file(s) were previously marked as having 100% SingleCov test coverage (had no `coverage:` option) but are no longer marked as such.\n" +
-        "Please increase test coverage in these files to maintain 100% coverage and remove `coverage:` usage.\n#{missing_complete.join("\n")}"
+        errors << ("The following file(s) were previously marked as having 100% SingleCov test coverage (had no `coverage:` option) but are no longer marked as such." \
+          "Please increase test coverage in these files to maintain 100% coverage and remove `coverage:` usage. \n #{missing_complete}")
       end
 
-      unless newly_complete.empty?
-        errors << "The following files are newly at 100% SingleCov test coverage. " +
-        "Please add the following to #{currently_complete_file} to ensure 100% coverage is maintained moving forward. " +
-        "#{newly_complete}"
+      if newly_complete.any?
+        errors << ("The following files are newly at 100% SingleCov test coverage. " \
+          "Please add the following to #{message} to ensure 100% coverage is maintained moving forward. \n" \
+          "#{newly_complete}")
       end
 
-      raise errors.join("\n") unless errors.empty?
+      raise errors.join("\n\n") unless errors.empty?
     end
 
     def setup(framework, root: nil, branches: true, err: $stderr)


### PR DESCRIPTION
Adds checks to ensure that:

1) Tests with no uncovered lines continue to have no uncovered lines.
2) When tests are added which drives the uncovered lines to zero, those tests are added to the list so that they will be maintained a no uncovered lines moving forward.

I will send a slack message to talk more about the use case that drove this PR.

Thanks for your feedback and consideration :)