### PR TITLE
Enables packwerk components public structure support

### DIFF
--- a/lib/single_cov.rb
+++ b/lib/single_cov.rb
@@ -4,6 +4,7 @@ module SingleCov
   MAX_OUTPUT = 40
   RAILS_APP_FOLDERS = ["models", "serializers", "helpers", "controllers", "mailers", "views", "jobs", "channels"]
   UNCOVERED_COMMENT_MARKER = /#.*uncovered/
+  PREFIXES_TO_IGNORE = []
 
   class << self
     # enable coverage reporting: path to output file, changed by forking-test-runner at runtime to combine many reports
@@ -356,6 +357,14 @@ module SingleCov
         raise "#{file} includes neither 'test' nor 'spec' folder ... unable to resolve"
       end
 
+      # Looking if the filedir starts with prefix that we wounld like to omit at this point (e.g. 'public' dir)
+      filenames_arr = file_part.split('/')
+      prefix = if PREFIXES_TO_IGNORE.any? && PREFIXES_TO_IGNORE.include?(filenames_arr.first)
+         filenames_arr.shift
+      end
+
+      file_part = filenames_arr.join('/')
+
       # rails things live in app
       file_part[0...0] = if file_part =~ /^(?:#{RAILS_APP_FOLDERS.map { |f| Regexp.escape(f) }.join('|')})\//
         "app/"
@@ -369,6 +378,9 @@ module SingleCov
       if !file_part.sub!(/_(?:test|spec)\.rb\b.*/, '.rb') && !file_part.sub!(/\/test_/, "/")
         raise "Unable to remove test extension from #{file} ... /test_, _test.rb and _spec.rb are supported"
       end
+
+      #put back the prefix if exists
+      file_part[0...0] = "#{prefix}/" if prefix
 
       # put back the subfolder
       file_part[0...0] = "#{subfolder}/" unless subfolder.empty?

--- a/specs/single_cov_spec.rb
+++ b/specs/single_cov_spec.rb
@@ -426,17 +426,39 @@ describe SingleCov do
       SingleCov.send(:guess_covered_file, "#{SingleCov.send(:root)}/#{test}:34:in `foobar'")
     end
 
-    {
-      "test/models/xyz_test.rb" => "app/models/xyz.rb",
-      "test/lib/xyz_test.rb" => "lib/xyz.rb",
-      "spec/lib/xyz_spec.rb" => "lib/xyz.rb",
-      "test/xyz_test.rb" => "lib/xyz.rb",
-      "test/test_xyz.rb" => "lib/xyz.rb",
-      "plugins/foo/test/lib/xyz_test.rb" => "plugins/foo/lib/xyz.rb",
-      "plugins/foo/test/models/xyz_test.rb" => "plugins/foo/app/models/xyz.rb"
-    }.each do |test, file|
-      it "maps #{test} to #{file}" do
-        expect(file_under_test(test)).to eq file
+    context 'with PREFIXES_TO_IGNORE has default value' do
+      {
+        "component/foo/test/public/models/xyz_test.rb" => "component/foo/lib/public/models/xyz.rb",
+        "test/models/xyz_test.rb" => "app/models/xyz.rb",
+        "test/lib/xyz_test.rb" => "lib/xyz.rb",
+        "spec/lib/xyz_spec.rb" => "lib/xyz.rb",
+        "test/xyz_test.rb" => "lib/xyz.rb",
+        "test/test_xyz.rb" => "lib/xyz.rb",
+        "plugins/foo/test/lib/xyz_test.rb" => "plugins/foo/lib/xyz.rb",
+        "plugins/foo/test/models/xyz_test.rb" => "plugins/foo/app/models/xyz.rb",
+      }.each do |test, file|
+        it "maps #{test} to #{file}" do
+          expect(file_under_test(test)).to eq file
+        end
+      end
+    end
+
+    context('with PREFIXES_TO_IGNORE set to custom directory') do
+      before { stub_const('SingleCov::PREFIXES_TO_IGNORE', ['public']) }
+
+      {
+        "component/foo/test/public/models/xyz_test.rb" => "component/foo/public/app/models/xyz.rb",
+        "test/models/xyz_test.rb" => "app/models/xyz.rb",
+        "test/lib/xyz_test.rb" => "lib/xyz.rb",
+        "spec/lib/xyz_spec.rb" => "lib/xyz.rb",
+        "test/xyz_test.rb" => "lib/xyz.rb",
+        "test/test_xyz.rb" => "lib/xyz.rb",
+        "plugins/foo/test/lib/xyz_test.rb" => "plugins/foo/lib/xyz.rb",
+        "plugins/foo/test/models/xyz_test.rb" => "plugins/foo/app/models/xyz.rb",
+      }.each do |test, file|
+        it "maps #{test} to #{file}" do
+          expect(file_under_test(test)).to eq file
+        end
       end
     end
 


### PR DESCRIPTION
While introducing custom structure in applications (like spiriting it in custom folders using [Packwerk](https://github.com/Shopify/packwerk/blob/main/USAGE.md) ) it would be great to have a way to configure SingleCov's way to guess file paths which use custom prefixes 