### PR TITLE
Assert Full Coverage check includes tests with configured files.

### DIFF
--- a/lib/single_cov.rb
+++ b/lib/single_cov.rb
@@ -78,7 +78,7 @@ module SingleCov
 
     def assert_full_coverage(tests: default_tests, currently_complete: [], location: nil)
       location ||= caller(0..1)[1].split(':in').first
-      complete = tests.select { |file| File.read(file) =~ /SingleCov.covered!(\s*|\s*\#.*)$/ }
+      complete = tests.reject { |file| File.read(file) =~ /SingleCov.covered!(.*)uncovered:(.*)$/ }
       missing_complete = currently_complete - complete
       newly_complete = complete - currently_complete
       errors = []

--- a/specs/single_cov_spec.rb
+++ b/specs/single_cov_spec.rb
@@ -450,6 +450,22 @@ describe SingleCov do
         change_file('test/a_test.rb', 'SingleCov.covered!', 'SingleCov.covered! uncovered: 12') { call }
       end.to raise_error(/test\/a_test.rb/)
     end
+
+    describe 'when file cannot be found from caller' do
+      let(:complete) { ["test/b_test.rb"] }
+
+      around { |test| move_file('test/a_test.rb', 'test/b_test.rb', &test) }
+
+      it "works when files covered and configured" do
+        change_file('test/b_test.rb', 'SingleCov.covered!', 'SingleCov.covered! file: lib/a.rb') { call }
+      end
+
+      it "alerts when files lost coverage and are configured" do
+        expect do
+          change_file('test/b_test.rb', 'SingleCov.covered!', 'SingleCov.covered!(uncovered: 12, file: lib/a.rb)') { call }
+        end.to raise_error(/test\/b_test.rb/)
+      end
+    end
   end
 
   describe ".file_under_test" do


### PR DESCRIPTION
Previously assert_full_coverage only considered files that have `SingleCov.covered!` as 100% covered

But files that are configuring a file
`SingleCov.covered! file: test/a_test.rb` should also be considered 100% covered if no `uncovered` value is set