### PR TITLE
assert_full_coverage ignores not_covered and code comments

### DIFF
--- a/lib/single_cov.rb
+++ b/lib/single_cov.rb
@@ -78,7 +78,7 @@ module SingleCov
 
     def assert_full_coverage(tests: default_tests, currently_complete: [], location: nil)
       location ||= caller(0..1)[1].split(':in').first
-      complete = tests.reject { |file| File.read(file) =~ /SingleCov.covered!(.*)uncovered:(.*)$/ }
+      complete = tests.select { |file| File.read(file) =~ /SingleCov.covered!(?:(?!uncovered).)*(\s*|\s*\#.*)$/ }
       missing_complete = currently_complete - complete
       newly_complete = complete - currently_complete
       errors = []

--- a/specs/single_cov_spec.rb
+++ b/specs/single_cov_spec.rb
@@ -451,6 +451,15 @@ describe SingleCov do
       end.to raise_error(/test\/a_test.rb/)
     end
 
+    it "ignores files not_covered" do
+      complete.pop
+      change_file('test/a_test.rb', 'SingleCov.covered!', 'SingleCov.not_covered!') { call }
+    end
+
+    it "ignores files with uncovered commented out" do
+      change_file('test/a_test.rb', 'SingleCov.covered!', 'SingleCov.covered! # uncovered: 12') { call }
+    end
+
     describe 'when file cannot be found from caller' do
       let(:complete) { ["test/b_test.rb"] }
 


### PR DESCRIPTION
Last PR switched to reject, this was allowing SingleCov.not_covered! to be treated as 100% covered files.

This fixes the bug and also ensures commenting out `uncovered` is handled correctly