### PR TITLE
Add Ruby 3.2 to the CI matrix.  Update checkout action version.

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.7', '3.0', '3.1' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
         task: [ 'spec' ]
         include:
         - ruby: 2.7 # keep in sync with lowest version
           task: rubocop
     name: ${{ matrix.ruby }} rake ${{ matrix.task }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
Runs green on my fork.