### PR TITLE
make missing else explicit

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -70,11 +70,13 @@ SingleCov::PREFIXES_TO_IGNORE << "public"
 
 ### Missing coverage for implicit `else` in `if` or `case` statements
 
+When a report shows for example `1:14-16 # else`, that indicates that the implicit else is not covered.
+
 ```ruby
-# needs one test case for true and one for false (implicit else)
+# needs 2 tests: one for `true` and one for `false`
 raise if a == b
 
-# needs one test case for `when b` and one for `else`  (implicit else)
+# needs 2 tests: one for `when b` and one for `else`
 case a
 when b
 end

--- a/lib/single_cov.rb
+++ b/lib/single_cov.rb
@@ -146,13 +146,7 @@ module SingleCov
     def uncovered(coverage)
       return coverage unless coverage.is_a?(Hash) # just lines
 
-      # [nil, 1, 0, 1, 0] -> [3, 5]
-      uncovered_lines = coverage.fetch(:lines)
-        .each_with_index
-        .select { |c, _| c == 0 }
-        .map { |_, i| i + 1 }
-        .compact
-
+      uncovered_lines = indexes(coverage.fetch(:lines), 0).map { |i| i + 1 }
       uncovered_branches = uncovered_branches(coverage[:branches] || {})
       uncovered_branches.reject! { |k| uncovered_lines.include?(k[0]) } # remove duplicates
 
@@ -195,6 +189,10 @@ module SingleCov
 
     def glob(pattern)
       Dir["#{root}/#{pattern}"].map! { |f| f.sub("#{root}/", '') }
+    end
+
+    def indexes(list, find)
+      list.each_with_index.filter_map { |v, i| i if v == find }
     end
 
     # do not ask for coverage when SimpleCov already does or it conflicts

--- a/specs/single_cov_spec.rb
+++ b/specs/single_cov_spec.rb
@@ -276,7 +276,15 @@ describe SingleCov do
           change_file("lib/a.rb", "i == 0", "i == 0 if i if 0 if false") do
             result = sh "ruby test/a_test.rb", fail: true
             expect(result).to include ".lib/a.rb new uncovered lines introduced (3 current vs 0 configured)"
-            expect(result).to include "lib/a.rb:4:19-23\nlib/a.rb:4:19-33\nlib/a.rb:4:19-38"
+            expect(result).to include "lib/a.rb:4:19-23\nlib/a.rb:4:19-33 # else\nlib/a.rb:4:19-38 # else"
+          end
+        end
+
+        it "complains about missing else coverage" do
+          change_file("lib/a.rb", "2.times", "1.times") do
+            result = sh "ruby test/a_test.rb", fail: true
+            expect(result).to include ".lib/a.rb new uncovered lines introduced (1 current vs 0 configured)"
+            expect(result).to include "lib/a.rb:4:19-33 # else"
           end
         end
 


### PR DESCRIPTION
90+% of complaints come from "it says there is missing coverage, but that line is covered" and then it turns out to be an implicit else so let's avoid that